### PR TITLE
Move Electron Builder config to dedicated file

### DIFF
--- a/mobile/electron-builder-config.yaml
+++ b/mobile/electron-builder-config.yaml
@@ -1,4 +1,14 @@
 appId: "fr.chobert.chobchat"
+extraMetadata:
+  main: "main.js"
+files:
+  - from: "dist/main/"
+    to: "./"
+    filter: ["**/*"]
+  - from: "dist/renderer/"
+    to: "./"
+    filter: ["**/*"]
+  - package.json
 productName: "ChobChat"
 linux:
   executableName: "chobchat"

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -82,24 +82,5 @@
   "repository": {
     "type": "git",
     "url": "github:barodeur/chobchat"
-  },
-  "build": {
-    "extraMetadata": {
-      "main": "main.js"
-    },
-    "files": [
-      {
-        "from": "dist/main/",
-        "to": "./",
-        "filter": ["**/*"]
-      },
-      {
-        "from": "dist/renderer",
-        "to": "./",
-        "filter": ["**/*"]
-      },
-      "package.json",
-      "**/node_modules/**/*"
-    ]
   }
 }


### PR DESCRIPTION
So far the config was splitted between the existing dedicated file `electron-builder-config.yaml` and the `package.json` `"build"` section.
