### PR TITLE
Prevent input zoom on mobile

### DIFF
--- a/mobile/pages/_app.js
+++ b/mobile/pages/_app.js
@@ -1,0 +1,14 @@
+import Head from 'next/head'
+
+function MyApp({ Component, pageProps }) {
+  return (
+    <>
+      <Head>
+        <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
+      </Head>
+      <Component {...pageProps} />
+    </>
+  )
+}
+
+export default MyApp


### PR DESCRIPTION
This should prevent mobile browser from zooming automatically on the composer input when focussed.
