### PR TITLE
Update `trim-newlines` to fix CVE-2021-33623

### DIFF
--- a/mobile/package.json
+++ b/mobile/package.json
@@ -70,7 +70,8 @@
   },
   "resolutions": {
     "axios": "^0.21.2",
-    "immer": "^9.0.6"
+    "immer": "^9.0.6",
+    "trim-newlines": "~3.0.1"
   },
   "private": true,
   "name": "chobchat",

--- a/mobile/yarn.lock
+++ b/mobile/yarn.lock
@@ -16710,10 +16710,10 @@ tree-kill@1.2.2:
   resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc"
   integrity sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==
 
-trim-newlines@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613"
-  integrity sha1-WIeWa7WCpFA6QetST301ARgVphM=
+trim-newlines@^1.0.0, trim-newlines@~3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-3.0.1.tgz#260a5d962d8b752425b32f3a7db0dcacd176c144"
+  integrity sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==
 
 truncate-utf8-bytes@^1.0.0:
   version "1.0.2"


### PR DESCRIPTION
This should fix CVE-2021-33623
