### PR TITLE
Update `node-forge` to 1.0.0

### DIFF
--- a/mobile/package.json
+++ b/mobile/package.json
@@ -74,6 +74,7 @@
     "glob-parent": "~5.1.2",
     "immer": "^9.0.6",
     "node-fetch": "~2.6.7",
+    "node-forge": "~1.0.0",
     "trim-newlines": "~3.0.1"
   },
   "private": true,

--- a/mobile/yarn.lock
+++ b/mobile/yarn.lock
@@ -12503,10 +12503,10 @@ node-fetch@2.6.1, node-fetch@^1.0.1, node-fetch@^2.2.0, node-fetch@^2.6.0, node-
   dependencies:
     whatwg-url "^5.0.0"
 
-node-forge@0.10.0, node-forge@^0.10.0:
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.10.0.tgz#32dea2afb3e9926f02ee5ce8794902691a676bf3"
-  integrity sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==
+node-forge@0.10.0, node-forge@^0.10.0, node-forge@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.0.0.tgz#a025e3beeeb90d9cee37dae34d25b968ec3e6f15"
+  integrity sha512-ShkiiAlzSsgH1IwGlA0jybk9vQTIOLyJ9nBd0JTuP+nzADJFLY0NoDijM2zvD/JaezooGu3G2p2FNxOAK6459g==
 
 node-html-parser@^1.2.12:
   version "1.4.9"


### PR DESCRIPTION
This should fix:
- CVE-2022-0122
- GHSA-5rrq-pxf6-6jx5
- GHSA-gf8q-jrpm-jvxq
