### PR TITLE
Prevent duplicated page opening

### DIFF
--- a/mobile/src/Link.res
+++ b/mobile/src/Link.res
@@ -1,0 +1,18 @@
+open ReactNative
+
+@react.component
+let make = (~href, ~children, ~textStyle=?, ()) => {
+  let handlePress = React.useCallback1(_ => {
+    switch PlatformX.platform {
+    | Mobile(_) => Linking.openURL(href)->ignore
+    | _ => ()
+    }
+  }, [href])
+
+  <TouchableOpacity onPress=handlePress>
+    {
+      let style = textStyle
+      <TextX accessibilityRole=#link href ?style> {children} </TextX>
+    }
+  </TouchableOpacity>
+}

--- a/mobile/src/Version.res
+++ b/mobile/src/Version.res
@@ -18,14 +18,5 @@ let str = {
 }
 
 @react.component
-let make = (~color="rgba(0, 0, 0, 0.2)") => {
-  let handlePress = React.useMemo0(((), _) => {
-    Linking.openURL(url)->ignore
-  })
-
-  <TouchableOpacity onPress={handlePress}>
-    <TextX accessibilityRole=#link href=url style={Style.textStyle(~color, ())}>
-      {str->React.string}
-    </TextX>
-  </TouchableOpacity>
-}
+let make = (~color="rgba(0, 0, 0, 0.2)") =>
+  <Link href=url textStyle={Style.textStyle(~color, ())}> {str->React.string} </Link>


### PR DESCRIPTION
This should prevent two browser windows from opening when the version number is clicked.