### PR TITLE
Bump `url-parse` version to `1.5.10`

### DIFF
--- a/mobile/package.json
+++ b/mobile/package.json
@@ -83,7 +83,8 @@
     "node-fetch": "~2.6.7",
     "node-forge": "~1.0.0",
     "postcss": "~8.2.13",
-    "trim-newlines": "~3.0.1"
+    "trim-newlines": "~3.0.1",
+    "url-parse": "~1.5.9"
   },
   "private": true,
   "name": "chobchat",

--- a/mobile/yarn.lock
+++ b/mobile/yarn.lock
@@ -16590,10 +16590,10 @@ url-parse-lax@^3.0.0:
   dependencies:
     prepend-http "^2.0.0"
 
-url-parse@^1.4.3, url-parse@^1.4.4, url-parse@^1.4.7, url-parse@^1.5.3:
-  version "1.5.7"
-  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.7.tgz#00780f60dbdae90181f51ed85fb24109422c932a"
-  integrity sha512-HxWkieX+STA38EDk7CE9MEryFeHCKzgagxlGvsdS7WBImq9Mk+PGwiT56w82WI3aicwJA8REp42Cxo98c8FZMA==
+url-parse@^1.4.3, url-parse@^1.4.4, url-parse@^1.4.7, url-parse@^1.5.3, url-parse@~1.5.9:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.10.tgz#9d3c2f736c1d75dd3bd2be507dcc111f1e2ea9c1"
+  integrity sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==
   dependencies:
     querystringify "^2.1.1"
     requires-port "^1.0.0"


### PR DESCRIPTION
This should fix:

- CVE-2022-0691
- CVE-2022-0686
